### PR TITLE
`ACCESS_BACKGROUND_LOCATION` permission added

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 


### PR DESCRIPTION
So that the location continues being provided even when the app isn't in foreground or when the phone is locked. Without that permission, even despite using a proper foreground service as you correctly do it, location updates and NMEA messages stop being served by `LocationManager` a few seconds after the app is "closed".