### PR TITLE
Allow localbroadcast in add server

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="settings_icon_description">settings</string>
     <string name="add_icon_description">add server</string>
 
+    <string name="broadcast_server">Select Broadcast interface</string>
     <string name="udp_server">UDP Server</string>
     <string name="tcp_server">TCP Server</string>
 
@@ -47,6 +48,7 @@
 
     <string name="add_dialog_invalid_data">Server data is invalid</string>
     <string name="add_dialog_add_button_text">Add</string>
+    <string name="add_dialog_add_broadcast_button_text">Broadcast address</string>
 
     #Main Screen Server Submenu
 


### PR DESCRIPTION
I'm not a real Kotlin developer, please let me know if there are any issues.

Allow the string "localbroadcast" in server creation.

This string is resolved when the server is started to the first broadcast address of the available network interfaces.
The global broadcast IP (255.255.255.255) has issues with VPN solutions, the local broadcast does not.