### PR TITLE
Control the number of NMEA messages being processed

### DIFF
--- a/app/src/main/java/io/github/project_kaat/gpsdrelay/database/Settings.kt
+++ b/app/src/main/java/io/github/project_kaat/gpsdrelay/database/Settings.kt
@@ -13,7 +13,8 @@ data class Settings(
     val id: Int,
     val autostartEnabled : Boolean,
     val autostartNetworkTimeoutS : Int,
-    val nmeaGenerationIntervalMs : Long
+    val nmeaGenerationIntervalMs : Long,
+    val nmeaIncludeFilter : String
 )
 
 @Dao

--- a/app/src/main/java/io/github/project_kaat/gpsdrelay/gpsdRelay.kt
+++ b/app/src/main/java/io/github/project_kaat/gpsdrelay/gpsdRelay.kt
@@ -32,7 +32,8 @@ class gpsdRelay : Application() {
                 1,
                 false,
                 60,
-                1000
+                1000,
+                ""
             )
         )
 

--- a/app/src/main/java/io/github/project_kaat/gpsdrelay/nmeaServerService.kt
+++ b/app/src/main/java/io/github/project_kaat/gpsdrelay/nmeaServerService.kt
@@ -284,7 +284,7 @@ class nmeaServerService : Service(), OnNmeaMessageListener, LocationListener {
     override fun onNmeaMessage(p0: String?, p1: Long) {
         //Log.i("SERVICE", "nmea message received: ${p0}")
 
-        if (p0 != null && filterContainsNmeaType(p0)) {
+        if (p0 != null && (nmeaIncludeFilter.isEmpty() || filterContainsNmeaType(p0))) {
             serverList.forEach() {
                 if (it.isConnected()) {
                     it.send(OutgoingMessage(isGenerated = false, p0))
@@ -325,6 +325,7 @@ class nmeaServerService : Service(), OnNmeaMessageListener, LocationListener {
                     serverList += udpSocketServer(udpEnabled)
                 }
 
+                nmeaIncludeFilter.clear()
                 val settings = database.settingsDao.getSettings().first()[0]
                 val includeFilter = settings.nmeaIncludeFilter.split(",")
 

--- a/app/src/main/java/io/github/project_kaat/gpsdrelay/ui/SettingsScreen.kt
+++ b/app/src/main/java/io/github/project_kaat/gpsdrelay/ui/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import io.github.project_kaat.gpsdrelay.database.SettingsDao
 import kotlinx.coroutines.launch
 import io.github.project_kaat.gpsdrelay.R
@@ -50,6 +51,7 @@ fun SettingsScreen(settingsDao : SettingsDao) {
     var generationIntervalTmp by remember {mutableStateOf(settings[0].nmeaGenerationIntervalMs.toString())}
     var autoStartEnabledTmp by remember {mutableStateOf(settings[0].autostartEnabled)}
     var autoStartTimeoutTmp by remember {mutableStateOf(settings[0].autostartNetworkTimeoutS.toString())}
+    var includeFilterTmp by remember {mutableStateOf(settings[0].nmeaIncludeFilter)}
 
     var mutated by remember {mutableStateOf(false)}
 
@@ -72,7 +74,8 @@ fun SettingsScreen(settingsDao : SettingsDao) {
                                         1,
                                         autoStartEnabledTmp,
                                         autoStartTimeoutTmp.toInt(),
-                                        generationIntervalTmp.toLong()
+                                        generationIntervalTmp.toLong(),
+                                        nmeaIncludeFilter = includeFilterTmp
                                     )
                                 )
                             } catch (e : Exception) {
@@ -101,7 +104,6 @@ fun SettingsScreen(settingsDao : SettingsDao) {
                     mutated = true
                     generationIntervalTmp = it
                 })
-
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(stringResource(R.string.settings_autostart_title))
                 Checkbox(checked = autoStartEnabledTmp, onCheckedChange = {
@@ -125,10 +127,22 @@ fun SettingsScreen(settingsDao : SettingsDao) {
                     mutated = true
                     autoStartTimeoutTmp = it
                 })
-
-
-
+            Text(
+                text = stringResource(R.string.settings_nmea_include_filter_header),
+                fontSize = 14.sp
+            )
+            Text(
+                text = stringResource(R.string.settings_nmea_include_filter_sub_header),
+                fontSize = 12.sp
+            )
+            OutlinedTextField(
+                label = { Text(stringResource(R.string.settings_nmea_include_filter)) },
+                value = includeFilterTmp,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                onValueChange = {
+                    mutated = true
+                    includeFilterTmp = it
+                })
         }
     }
-
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="settings_generation_interval_title">NMEA generation interval (ms)</string>
     <string name="settings_autostart_title">Start service when Android boots</string>
     <string name="settings_autostart_timeout_title">Autostart timeout (s)</string>
+    <string name="settings_nmea_include_filter_header">Specify a comma separated list of NMEA types to relay</string>
+    <string name="settings_nmea_include_filter_sub_header">For example: \"GPRMC,GPGGA\", an empty list relays all types</string>
+    <string name="settings_nmea_include_filter">NMEA message type to relay</string>
 
     <string name="settings_lockscreen_warning">gpsdRelay will only autostart after the device is unlocked for the first time</string>
 


### PR DESCRIPTION
I'm not a real Kotlin developer, please let me know if there are any issues.

Allow filtering of  relayed NMEA messages.

Currently all NMEA messages are relayed, this causes a lot of unneeded network traffic.
Also it seems the number of messages currently being relayed causes issues with the app, causing messages to be delayed.
With filtering enabled, this is no longer the case.