### PR TITLE
fix checksum format in generated NMEA

### DIFF
--- a/app/src/main/java/io/github/project_kaat/gpsdrelay/nmeaServerService.kt
+++ b/app/src/main/java/io/github/project_kaat/gpsdrelay/nmeaServerService.kt
@@ -118,7 +118,7 @@ class nmeaServerService : Service(), OnNmeaMessageListener, LocationListener {
             }
         }
 
-        return checksum.toString(16)
+        return String.format("%02X", checksum)
     }
 
     private fun getGNGGA(p0 : Location) : String {


### PR DESCRIPTION
Hi,
Thank you for this great tool.
I had some issues with the checksum of the generated NMEA sentences.
The NMEA-0183 norm explicitly requires:
- the checksum to be uppercase
- the checksum to always be composed of two characters, for example `*0B\r\n` instead of `*B\r\n`

This fixes both problems.